### PR TITLE
feat: open pages inline without preview bar

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -5,11 +5,9 @@ const els = {
   sidebar: document.getElementById('sidebar'),
   menuBtn: document.getElementById('menuBtn'),
   backdrop: document.getElementById('backdrop'),
-  previewWrap: document.getElementById('previewWrap'),
-  preview: document.getElementById('preview'),
-  previewTitle: document.getElementById('previewTitle'),
-  openInNew: document.getElementById('openInNew'),
-  closePreview: document.getElementById('closePreview')
+  welcome: document.getElementById('welcome'),
+  viewer: document.getElementById('viewer'),
+  backBtn: document.getElementById('backBtn')
 };
 
 const state = { data: null, expanded: new Set(), filter: '' };
@@ -38,7 +36,7 @@ async function init(){
     if(firstId) state.expanded.add(firstId);
     render();
     wireSearch();
-    wirePreview();
+    wireViewer();
   }catch(err){
     console.error(err);
     els.cats.innerHTML = `<div class="muted" style="padding:12px">Ошибка загрузки JSON: ${escapeHtml(String(err.message||err))}</div>`;
@@ -100,40 +98,50 @@ function wireSearch(){
 function match(text, q){ return String(text||'').toLowerCase().includes(q); }
 function highlight(text){ if(!state.filter) return escapeHtml(text); const re = new RegExp(`(${escapeReg(state.filter)})`, 'ig'); return escapeHtml(text).replace(re, '<mark>$1</mark>'); }
 
-// --- Preview
-function wirePreview(){
-  els.closePreview.addEventListener('click', () => {
-    els.preview.src = 'about:blank';
-    els.previewWrap.classList.remove('active');
-  });
+// --- Page viewer
+function wireViewer(){
+  els.backBtn.addEventListener('click', () => history.back());
   window.addEventListener('hashchange', tryOpenFromHash);
   tryOpenFromHash();
 }
 
 function onOpenPage(e){
-  // On mobile open the page directly, on desktop open preview iframe
   const url = this.getAttribute('data-url');
-  const title = this.getAttribute('data-title');
   if(!deviceHasWide()) return; // allow default navigation on mobile
   e.preventDefault();
-  openPreview(url, title);
   toggleSidebar(false);
-  location.hash = '#'+encodeURIComponent(url);
+  if(location.hash !== '#'+encodeURIComponent(url)){
+    location.hash = '#'+encodeURIComponent(url);
+  }else{
+    openPage(url);
+  }
 }
 
 function deviceHasWide(){ return window.matchMedia('(min-width: 1025px)').matches; }
 
-function openPreview(url, title){
-  els.previewTitle.innerHTML = `🔗 ${escapeHtml(title)}`;
-  els.preview.src = url;
-  els.openInNew.href = url;
-  els.previewWrap.classList.add('active');
+function openPage(url){
+  els.viewer.src = url;
+  els.viewer.classList.add('active');
+  els.grid.style.display = 'none';
+  els.welcome.style.display = 'none';
+  els.backBtn.style.display = 'inline-flex';
+}
+
+function closePage(){
+  els.viewer.src = 'about:blank';
+  els.viewer.classList.remove('active');
+  els.grid.style.display = '';
+  els.welcome.style.display = '';
+  els.backBtn.style.display = 'none';
 }
 
 function tryOpenFromHash(){
   const h = decodeURIComponent(location.hash.replace(/^#/, ''));
-  if(h && /^[^#?].+$/i.test(h)){
-    openPreview(h, 'Предпросмотр');
+  if(h){
+    openPage(h);
+    toggleSidebar(false);
+  }else{
+    closePage();
   }
 }
 

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -46,17 +46,13 @@ body {
 .topbar { display: flex; align-items: center; justify-content: space-between; gap: 8px; padding: 12px 14px; border-bottom: 1px solid var(--border); background: linear-gradient(180deg, rgba(255,255,255,.02), transparent); }
 .btn { appearance: none; border: 1px solid var(--border); background: var(--panel); color: var(--text); border-radius: 12px; padding: 10px 12px; cursor: pointer; }
 .btn:hover { border-color: rgba(91,156,255,.6); }
-.content { height: calc(100% - 58px); display: grid; grid-template-rows: auto 1fr; }
+.content { height: calc(100% - 58px); display: grid; grid-template-rows: auto 1fr; position: relative; }
 .welcome { padding: 18px; display: grid; gap: 8px; border-bottom: 1px dashed var(--border); }
 .grid { padding: 14px; overflow: auto; }
 .hint { color: var(--muted); font-size: 12px; }
-/* Live preview area */
-.preview-wrap { position: relative; height: 100%; border-top: 1px solid var(--border); display: none; }
-.preview-wrap.active { display: block; }
-.preview-bar { display: flex; align-items: center; justify-content: space-between; gap: 10px; padding: 8px 12px; background: var(--panel); border-bottom: 1px solid var(--border); }
-.preview-title { display: flex; align-items: center; gap: 8px; font-weight: 600; }
-.preview-actions { display: flex; gap: 8px; }
-iframe.preview { width: 100%; height: calc(100% - 42px); border: 0; background: #fff; }
+/* Page viewer */
+.viewer { position: absolute; inset: 0; width: 100%; height: 100%; border: 0; background: #fff; display: none; }
+.viewer.active { display: block; }
 /* Mobile */
 .menu-toggle { display: none; }
 @media (max-width: 1024px) {
@@ -66,5 +62,4 @@ iframe.preview { width: 100%; height: calc(100% - 42px); border: 0; background: 
   .menu-toggle { display: inline-flex; align-items: center; gap: 8px; }
   .backdrop { display:none; position: fixed; inset: 0; background: rgba(0,0,0,.4); z-index: 9; }
   .backdrop.show { display:block; }
-  .preview-wrap { height: calc(100dvh - 58px); }
 }

--- a/index.html
+++ b/index.html
@@ -26,6 +26,7 @@
     <main class="main">
       <header class="topbar">
         <button class="btn menu-toggle" id="menuBtn">☰ Меню</button>
+        <button class="btn" id="backBtn" style="display:none">← Назад</button>
       </header>
 
       <section class="content">
@@ -40,16 +41,7 @@
           </div>
         </div>
         <div class="grid" id="grid"></div>
-        <div class="preview-wrap" id="previewWrap">
-          <div class="preview-bar">
-            <div class="preview-title" id="previewTitle">🔗 Предпросмотр</div>
-            <div class="preview-actions">
-              <a class="btn" id="openInNew" target="_blank" rel="noopener">Открыть в новой вкладке</a>
-              <button class="btn" id="closePreview">Закрыть</button>
-            </div>
-          </div>
-          <iframe class="preview" id="preview"></iframe>
-        </div>
+        <iframe class="viewer" id="viewer"></iframe>
       </section>
     </main>
   </div>


### PR DESCRIPTION
## Summary
- remove preview toolbar and iframe wrapper
- show pages inline in main area with browser back support

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a02ef8022c83259cb693077ad6da6f