### PR TITLE
Hide back button when history is empty and remove open-right chip

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -11,6 +11,7 @@ const els = {
 };
 
 const state = { data: null, expanded: new Set(), filter: '' };
+const initialHistoryLength = history.length;
 
 // --- Sidebar menu toggle (mobile)
 els.menuBtn?.addEventListener('click', () => toggleSidebar(true));
@@ -83,7 +84,6 @@ function pageItem(cat, p){
         <div class="page-title">${highlight(p.title)}</div>
         ${p.desc ? `<div class="page-desc">${highlight(p.desc)}</div>` : ''}
       </div>
-      <div class="open-chip">${deviceHasWide() ? 'Открыть справа' : 'Открыть'}</div>
     </a>`;
 }
 
@@ -126,7 +126,7 @@ function openPage(url){
   els.viewer.classList.add('active');
   els.grid.style.display = 'none';
   els.welcome.style.display = 'none';
-  els.backBtn.style.display = 'inline-flex';
+  els.backBtn.style.display = history.length > initialHistoryLength ? 'inline-flex' : 'none';
 }
 
 function closePage(){

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -34,13 +34,12 @@ body {
 .cat-title { display: flex; align-items: center; gap: 10px; font-weight: 600; }
 .cat-desc { margin: 6px 4px 0 34px; color: var(--muted); font-size: 12px; }
 .pages { margin-top: 8px; display: grid; gap: 6px; padding-left: 6px; }
-.page-link { text-decoration: none; color: inherit; padding: 10px; border: 1px solid var(--border); border-radius: 12px; display: grid; grid-template-columns: 28px 1fr auto; gap: 10px; align-items: center; background: var(--panel-2); }
+.page-link { text-decoration: none; color: inherit; padding: 10px; border: 1px solid var(--border); border-radius: 12px; display: grid; grid-template-columns: 28px 1fr; gap: 10px; align-items: center; background: var(--panel-2); }
 .page-link:hover{ border-color: rgba(91,156,255,.6); box-shadow: var(--shadow); }
 .page-emoji { font-size: 18px; line-height: 1; text-align: center; }
 .page-meta { display: grid; gap: 4px; }
 .page-title { font-weight: 600; }
 .page-desc { color: var(--muted); font-size: 12px; }
-.open-chip { font-size: 11px; padding: 4px 8px; border: 1px solid var(--border); border-radius: 100px; color: var(--muted); }
 /* Main */
 .main { position: relative; overflow: hidden; }
 .topbar { display: flex; align-items: center; justify-content: space-between; gap: 8px; padding: 12px 14px; border-bottom: 1px solid var(--border); background: linear-gradient(180deg, rgba(255,255,255,.02), transparent); }


### PR DESCRIPTION
## Summary
- Show back button only when there is history to return to
- Remove "Open right" chip from menu items and related styling

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/Pages/package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68a039394288832582906d03f75fffa0