### PR TITLE
Refactor physics page with separated assets

### DIFF
--- a/pages/physics/index.html
+++ b/pages/physics/index.html
@@ -12,7 +12,8 @@
     <div class="controls">
       <div class="range">
         <label for="t">Время t (с)</label>
-        <input id="t" type="range" min="0" max="12" step="0.01" value="0" />
+        <input id="t" type="range" min="0" max="60" step="0.01" value="0" />
+        <input id="tInput" type="number" step="0.01" value="0" style="width:90px" />
         <div class="pill"><span id="tVal">0.00</span> с</div>
       </div>
       <div>
@@ -23,6 +24,11 @@
         <label for="speed">|v₀| (пикс/с)</label>
         <input id="speed" type="number" step="5" value="90" style="width:90px" />
       </div>
+      <div>
+        <label for="scale">Масштаб</label>
+        <input id="scale" type="number" step="0.1" value="1" style="width:70px" />
+      </div>
+      <div class="small">Колесо мыши тоже масштабирует</div>
     </div>
 
     <div class="panes">
@@ -49,6 +55,20 @@
         <div class="row"><strong>Вращающаяся форма</strong><span class="small">через величины инерциальной системы</span></div>
         <div class="code" id="eqRot"></div>
       </section>
+    </div>
+
+    <div class="description">
+      <h3>Описание</h3>
+      <p>На экране показано движение частицы в двух системах отсчёта: слева — инерциальная (движение равномерное и прямолинейное), справа — вращающаяся (наблюдатель вращается вместе с системой). Траектория справа искривляется из-за дополнительных (фиктивных) сил.</p>
+      <ul>
+        <li><b>a</b> — ускорение; <b>a<sub>инерц</sub></b> — в инерциальной системе; <b>a′</b> — во вращающейся.</li>
+        <li><b>r</b>, <b>v</b> — положение и скорость; со штрихом — во вращающейся системе.</li>
+        <li><b>ω</b> — угловая скорость вращения системы (по оси z).</li>
+        <li><b>t</b> — время моделирования (с).</li>
+        <li><b>R(ωt)</b> — оператор (матрица) поворота на угол ωt.</li>
+        <li><b>v₀</b> — начальная скорость в инерциальной системе (модуль задаётся в поле |v₀|).</li>
+        <li><b>Масштаб</b> — коэффициент увеличения/уменьшения отображения; также можно крутить колесо мыши.</li>
+      </ul>
     </div>
   </div>
 

--- a/pages/physics/script.js
+++ b/pages/physics/script.js
@@ -1,166 +1,170 @@
 (function(){
-  // ====== Math helpers (2D + z=0 for cross products) ======
+  // ====== Math helpers (2D + z=0) ======
   const V = {
     add: (a,b)=>[a[0]+b[0], a[1]+b[1]],
     sub: (a,b)=>[a[0]-b[0], a[1]-b[1]],
     mul: (a,s)=>[a[0]*s, a[1]*s],
-    dot: (a,b)=>a[0]*b[0]+a[1]*b[1],
-    len: a=>Math.hypot(a[0],a[1]),
   };
-  const crossZ = (w, r)=>[ -w*r[1], w*r[0] ]; // ω×r for 2D with ω along +z
-  const crossZOnVec = (w, v)=>[ -w*v[1], w*v[0] ];
-  const doubleCross = (w, r)=> crossZ(w, crossZ(w, r));
+  const crossZ = (w, r)=>[ -w*r[1], w*r[0] ];          // ω×r
+  const crossZOnVec = (w, v)=>[ -w*v[1], w*v[0] ];      // ω×v
+  const doubleCross = (w, r)=> crossZ(w, crossZ(w, r)); // ω×(ω×r)
   const rot = (ang, r)=>{ const c=Math.cos(ang), s=Math.sin(ang); return [c*r[0]-s*r[1], s*r[0]+c*r[1]]; };
 
-  // ====== Scene setup ======
+  // ====== DOM ======
   const cvI = document.getElementById('cvInert');
   const cvR = document.getElementById('cvRot');
   const gI = cvI.getContext('2d');
   const gR = cvR.getContext('2d');
   const tSlider = document.getElementById('t');
-  const tVal = document.getElementById('tVal');
+  const tInput  = document.getElementById('tInput');
+  const tVal    = document.getElementById('tVal');
   const omegaInput = document.getElementById('omega');
   const speedInput = document.getElementById('speed');
+  const scaleInput = document.getElementById('scale');
   const eqInert = document.getElementById('eqInert');
-  const eqRot = document.getElementById('eqRot');
+  const eqRot   = document.getElementById('eqRot');
 
   const centerI = [cvI.width/2, cvI.height/2];
   const centerR = [cvR.width/2, cvR.height/2];
 
-  // Initial conditions (in inertial frame)
+  // ====== State ======
   let r0 = [-140, -60];
-  let v0Dir = [1, 0.6]; // direction; will be normalized and scaled by |v0|
+  let v0Dir = [1, 0.6];
+  const pathI = [];
+  const pathR = [];
 
-  // For drawing history
-  const pathI = []; // inertial positions
-  const pathR = []; // rotating positions
-
-  function fmt(v){ return Array.isArray(v) ? `(${v[0].toFixed(2)}, ${v[1].toFixed(2)})` : (typeof v==='number'? v.toFixed(3):String(v)); }
-
-  // ====== Panning (per-canvas) ======
+  // Panning state per canvas
   function makePan(canvas){
     const state = { pan:[0,0], dragging:false, last:[0,0] };
-    const onDown = (e)=>{ state.dragging=true; canvas.classList.add('dragging'); state.last=[e.offsetX,e.offsetY]; };
-    const onMove = (e)=>{
+    canvas.addEventListener('mousedown', e=>{ state.dragging=true; canvas.classList.add('dragging'); state.last=[e.offsetX,e.offsetY]; });
+    canvas.addEventListener('mousemove', e=>{
       if(!state.dragging) return; const dx=e.offsetX-state.last[0], dy=e.offsetY-state.last[1];
-      state.pan[0]+=dx; state.pan[1]+=dy; state.last=[e.offsetX,e.offsetY]; update(); };
-    const onUp = ()=>{ state.dragging=false; canvas.classList.remove('dragging'); };
-    canvas.addEventListener('mousedown', onDown);
-    canvas.addEventListener('mousemove', onMove);
-    window.addEventListener('mouseup', onUp);
+      state.pan[0]+=dx; state.pan[1]+=dy; state.last=[e.offsetX,e.offsetY]; render();
+    });
+    window.addEventListener('mouseup', ()=>{ state.dragging=false; canvas.classList.remove('dragging'); });
+    // wheel zoom (global scaleInput changed for simplicity)
+    canvas.addEventListener('wheel', e=>{
+      e.preventDefault();
+      const factor = e.deltaY<0 ? 1.1 : 0.9;
+      const newScale = Math.min(3, Math.max(0.4, parseFloat(scaleInput.value||'1')*factor));
+      scaleInput.value = newScale.toFixed(2);
+      render();
+    }, {passive:false});
     return state;
   }
   const panI = makePan(cvI);
   const panR = makePan(cvR);
-  document.getElementById('resetI').onclick = ()=>{ panI.pan=[0,0]; update(); };
-  document.getElementById('resetR').onclick = ()=>{ panR.pan=[0,0]; update(); };
 
-  function drawGrid(g, center, pan, opts={}){
-    const { step=40, minor=8 } = opts;
+  document.getElementById('resetI').onclick = ()=>{ panI.pan=[0,0]; render(); };
+  document.getElementById('resetR').onclick = ()=>{ panR.pan=[0,0]; render(); };
+
+  // ====== Draw helpers ======
+  function drawGrid(g, center, pan, scale){
+    const step=40, minor=8;
     g.save();
     g.clearRect(0,0,g.canvas.width,g.canvas.height);
     g.translate(center[0] + pan[0], center[1] + pan[1]);
+    g.scale(scale, scale);
 
-    // minor grid
-    g.beginPath(); g.lineWidth=1; g.globalAlpha=0.15;
+    // minor
+    g.beginPath(); g.globalAlpha=0.15; g.lineWidth=1/scale;
     for(let x=-2000; x<=2000; x+=step/minor){ g.moveTo(x,-2000); g.lineTo(x,2000);}    
     for(let y=-2000; y<=2000; y+=step/minor){ g.moveTo(-2000,y); g.lineTo(2000,y);} 
     g.strokeStyle="#bcd3ff"; g.stroke();
 
-    // main grid
-    g.beginPath(); g.globalAlpha=0.25; g.lineWidth=1.5;
+    // main
+    g.beginPath(); g.globalAlpha=0.25; g.lineWidth=1.5/scale;
     for(let x=-2000; x<=2000; x+=step){ g.moveTo(x,-2000); g.lineTo(x,2000);}    
     for(let y=-2000; y<=2000; y+=step){ g.moveTo(-2000,y); g.lineTo(2000,y);} 
     g.strokeStyle="#6aa6ff"; g.stroke();
 
     // axes
-    g.globalAlpha=1; g.lineWidth=2.0; g.beginPath();
+    g.globalAlpha=1; g.lineWidth=2/scale; g.beginPath();
     g.moveTo(-2000,0); g.lineTo(2000,0);
     g.moveTo(0,-2000); g.lineTo(0,2000);
     g.strokeStyle="#ff9f6a"; g.stroke();
     g.restore();
   }
 
-  function drawParticle(g, center, pan, r, color){
-    g.save();
-    g.translate(center[0] + pan[0], center[1] + pan[1]);
-    g.beginPath(); g.arc(r[0], -r[1], 5, 0, Math.PI*2); g.fillStyle=color; g.fill();
+  function drawPath(g, center, pan, arr, color, scale){
+    if(arr.length<2) return; g.save(); g.translate(center[0]+pan[0], center[1]+pan[1]); g.scale(scale, scale);
+    g.beginPath(); g.moveTo(arr[0][0], -arr[0][1]);
+    for(let i=1;i<arr.length;i++) g.lineTo(arr[i][0], -arr[i][1]);
+    g.lineWidth=2/scale; g.globalAlpha=0.85; g.strokeStyle=color; g.stroke();
+    g.restore();
+  }
+  function drawPoint(g, center, pan, r, color, scale){
+    g.save(); g.translate(center[0]+pan[0], center[1]+pan[1]); g.scale(scale, scale);
+    g.beginPath(); g.arc(r[0], -r[1], 5/scale, 0, Math.PI*2); g.fillStyle=color; g.fill();
     g.restore();
   }
 
-  function drawPath(g, center, pan, arr, color){
-    if(arr.length<2) return; g.save(); g.translate(center[0] + pan[0], center[1] + pan[1]);
-    g.beginPath(); g.moveTo(arr[0][0], -arr[0][1]);
-    for(let i=1;i<arr.length;i++){ g.lineTo(arr[i][0], -arr[i][1]); }
-    g.lineWidth=2; g.globalAlpha=0.85; g.strokeStyle=color; g.stroke(); g.restore();
-  }
-
-  function eqVec(name, v){
-    return `<span class="vec">${name}</span> = <span class="num">(${Number(v[0]).toFixed(2)}, ${Number(v[1]).toFixed(2)})</span>`;
-  }
-
-  function update(){
+  // ====== Render ======
+  function render(){
     const t = parseFloat(tSlider.value);
+    tInput.value = t.toFixed(2);
     tVal.textContent = t.toFixed(2);
     const w = parseFloat(omegaInput.value);
     const vMag = parseFloat(speedInput.value);
+    const scale = Math.min(3, Math.max(0.4, parseFloat(scaleInput.value || '1')));
+    scaleInput.value = scale.toFixed(2);
 
-    // normalize direction
     const L = Math.hypot(v0Dir[0], v0Dir[1]);
     const v0 = [v0Dir[0]/L * vMag, v0Dir[1]/L * vMag];
 
-    // --- Inertial positions/velocities/accelerations ---
-    const rI = V.add(r0, V.mul(v0, t)); // uniform motion
+    // Inertial
+    const rI = V.add(r0, V.mul(v0, t));
     const vI = v0;
     const aI = [0,0];
 
-    // --- Rotating frame values (ω const) ---
-    const angle = -w*t; // map inertial -> rotating coordinates
+    // Rotating (ω const)
+    const angle = -w*t;
     const rR = rot(angle, rI);
-    const vR = rot(angle, V.sub(vI, crossZ(w, rI))); // v' = R(-wt)(v - ω×r)
-    const aR = rot(angle, V.sub( V.sub(aI, V.mul(crossZOnVec(w, vI), 2)), doubleCross(w, rI) )); // a' = R(-ωt)(a - 2ω×v - ω×(ω×r))
+    const vR = rot(angle, V.sub(vI, crossZ(w, rI)));
+    const aR = rot(angle, V.sub( V.sub(aI, V.mul(crossZOnVec(w, vI), 2)), doubleCross(w, rI) ));
 
-    // RHS check: a_inert from rotating values
     const aI_fromRot = rot(-angle, V.add( aR, V.add( V.mul(crossZOnVec(w, vR), 2), doubleCross(w, rR) )));
 
-    // store paths
+    // paths
     const idx = Math.round(t*60);
     pathI[idx] = rI; pathR[idx] = rR;
 
-    // --- Draw ---
-    drawGrid(gI, centerI, panI.pan);
-    drawPath(gI, centerI, panI.pan, pathI.filter(Boolean), '#9be370');
-    drawParticle(gI, centerI, panI.pan, rI, '#c2ffd6');
+    // draw
+    drawGrid(gI, centerI, panI.pan, scale);
+    drawPath(gI, centerI, panI.pan, pathI.filter(Boolean), '#9be370', scale);
+    drawPoint(gI, centerI, panI.pan, rI, '#c2ffd6', scale);
 
-    drawGrid(gR, centerR, panR.pan);
-    drawPath(gR, centerR, panR.pan, pathR.filter(Boolean), '#ffd68c');
-    drawParticle(gR, centerR, panR.pan, rR, '#fff0c2');
+    drawGrid(gR, centerR, panR.pan, scale);
+    drawPath(gR, centerR, panR.pan, pathR.filter(Boolean), '#ffd68c', scale);
+    drawPoint(gR, centerR, panR.pan, rR, '#fff0c2', scale);
 
-    // --- Equations (readable HTML) ---
+    // equations (HTML)
+    const fmt = (v)=>`<span class="num">(${v[0].toFixed(2)}, ${v[1].toFixed(2)})</span>`;
+
     eqInert.innerHTML = `
       <div class="mathline"><b>a</b><sub>инерц</sub> = R(ωt) · ( <b>a</b>' + 2 ω × <b>v</b>' + ω × (ω × <b>r</b>') )</div>
       <div class="mathline small">ω = (0,0,<span class="num">${w.toFixed(2)}</span>), t = <span class="num">${t.toFixed(2)}</span></div>
-      <div class="mathline small">${eqVec("r'", rR)}; ${eqVec("v'", vR)}; ${eqVec("a'", aR)}</div>
-      <div class="mathline small">⇒ <b>a</b><sub>инерц</sub> (расч) = ${eqVec("", aI_fromRot).replace('<span class="vec"></span> = ','')}</div>
+      <div class="mathline small"><b>r′</b> = ${fmt(rR)}; <b>v′</b> = ${fmt(vR)}; <b>a′</b> = ${fmt(aR)}</div>
+      <div class="mathline small">⇒ <b>a</b><sub>инерц</sub> (расч) = ${fmt(aI_fromRot)}</div>
     `;
 
     eqRot.innerHTML = `
-      <div class="mathline"><b>a</b>' = R(−ωt) · ( <b>a</b><sub>инерц</sub> − 2 ω × <b>v</b><sub>инерц</sub> − ω × (ω × <b>r</b><sub>инерц</sub>) )</div>
-      <div class="mathline small">${eqVec("r<sub>инерц</sub>", rI)}; ${eqVec("v<sub>инерц</sub>", vI)}; ${eqVec("a<sub>инерц</sub>", aI)}</div>
-      <div class="mathline small">⇒ <b>a</b>' = ${eqVec("", aR).replace('<span class="vec"></span> = ','')}</div>
+      <div class="mathline"><b>a</b>′ = R(−ωt) · ( <b>a</b><sub>инерц</sub> − 2 ω × <b>v</b><sub>инерц</sub> − ω × (ω × <b>r</b><sub>инерц</sub>) )</div>
+      <div class="mathline small"><b>r</b><sub>инерц</sub> = ${fmt(rI)}; <b>v</b><sub>инерц</sub> = ${fmt(vI)}; <b>a</b><sub>инерц</sub> = ${fmt(aI)}</div>
+      <div class="mathline small">⇒ <b>a</b>′ = ${fmt(aR)}</div>
     `;
   }
 
-  // interactions
-  for (const el of [tSlider, omegaInput, speedInput]){
-    el.addEventListener('input', update);
-    el.addEventListener('change', update);
+  // Events
+  for (const el of [tSlider, omegaInput, speedInput, scaleInput]){
+    el.addEventListener('input', render);
+    el.addEventListener('change', render);
   }
+  tInput.addEventListener('input', ()=>{
+    const val = parseFloat(tInput.value||'0');
+    tSlider.value = isFinite(val)? String(val) : '0';
+    render();
+  });
 
-  // Reset paths when ω or speed change
-  function resetPaths(){ pathI.length = 0; pathR.length = 0; }
-  omegaInput.addEventListener('change', resetPaths);
-  speedInput.addEventListener('change', resetPaths);
-
-  update();
+  render();
 })();

--- a/pages/physics/style.css
+++ b/pages/physics/style.css
@@ -2,7 +2,7 @@
 html,body{height:100%; margin:0; background:var(--bg); color:var(--fg); font-family:Inter,system-ui,Segoe UI,Roboto,Arial,sans-serif}
 h1{font-size:20px; margin:0 0 8px 0}
 .wrap{max-width:1120px; margin:16px auto; padding:16px}
-.controls{display:grid; grid-template-columns: 1fr auto auto; gap:12px; align-items:center; background:#111733; padding:12px 16px; border-radius:16px; box-shadow:0 6px 24px rgba(0,0,0,.25)}
+.controls{display:grid; grid-template-columns: 1fr auto auto auto auto; gap:12px; align-items:center; background:#111733; padding:12px 16px; border-radius:16px; box-shadow:0 6px 24px rgba(0,0,0,.25)}
 .range{display:flex; align-items:center; gap:10px}
 input[type="range"]{width:100%}
 .panes{margin-top:16px; display:grid; grid-template-columns:1fr 1fr; gap:16px}
@@ -21,8 +21,6 @@ label{font-size:12px; color:var(--muted)}
 .num{font-variant-numeric: tabular-nums}
 .toolbar{display:flex; gap:8px; align-items:center; margin-top:6px}
 .btn{font-size:12px; background:#0b183a; color:#cfe0ff; border:1px solid #243660; border-radius:10px; padding:6px 10px; cursor:pointer}
-.v{font-weight:700}
-.sub{font-size:0.9em; opacity:0.9}
-.vec{font-weight:700}
 .mathline{margin:2px 0}
+.description{margin-top:24px; background:#111733; padding:16px; border-radius:16px; font-size:14px; line-height:1.6; color:var(--muted)}
 @media (max-width:900px){ .panes, .eqs{grid-template-columns:1fr} }


### PR DESCRIPTION
## Summary
- Rebuild physics demo using provided code separated into HTML, CSS, and JS files
- Add numeric time input, scale control, and descriptive section for parameters
- Enable canvas panning with mouse wheel zoom

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a04e44ba608325ad91f73a7bd10935