### PR TITLE
Show category descriptions inside menu titles

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -52,10 +52,15 @@ function render(){
     return `
       <section class="cat" data-id="${escapeAttr(cat.id)}">
         <div class="cat-header" data-action="toggle">
-          <div class="cat-title"><span style="font-size:18px">${escapeHtml(cat.emoji||'📁')}</span><span>${escapeHtml(cat.title)}</span></div>
+          <div class="cat-title">
+            <span style="font-size:18px">${escapeHtml(cat.emoji||'📁')}</span>
+            <div>
+              <div class="cat-name">${escapeHtml(cat.title)}</div>
+              ${cat.desc ? `<div class="cat-desc">${escapeHtml(cat.desc)}</div>` : ''}
+            </div>
+          </div>
           <div class="muted">${isOpen ? '▾' : '▸'}</div>
         </div>
-        ${cat.desc ? `<div class="cat-desc">${escapeHtml(cat.desc)}</div>`: ''}
         ${isOpen ? `<div class="pages">${pages || emptyHint()}</div>` : ''}
       </section>`;
   }).join('');

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -31,8 +31,9 @@ body {
 .search input::placeholder{ color: var(--muted); }
 .cat { margin: 12px 0; }
 .cat-header { cursor: pointer; user-select: none; padding: 10px 12px; border-radius: 12px; display: flex; align-items: center; justify-content: space-between; border: 1px solid var(--border); background: rgba(255,255,255,.02); }
-.cat-title { display: flex; align-items: center; gap: 10px; font-weight: 600; }
-.cat-desc { margin: 6px 4px 0 34px; color: var(--muted); font-size: 12px; }
+.cat-title { display: flex; align-items: flex-start; gap: 10px; }
+.cat-name { font-weight: 600; }
+.cat-desc { margin-top: 2px; color: var(--muted); font-size: 12px; }
 .pages { margin-top: 8px; display: grid; gap: 6px; padding-left: 6px; }
 .page-link { text-decoration: none; color: inherit; padding: 10px; border: 1px solid var(--border); border-radius: 12px; display: grid; grid-template-columns: 28px 1fr; gap: 10px; align-items: center; background: var(--panel-2); }
 .page-link:hover{ border-color: rgba(91,156,255,.6); box-shadow: var(--shadow); }


### PR DESCRIPTION
## Summary
- Display category description inside the menu title block for each category
- Style menu titles to include description below the title

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a055b3bb188325b2e2b4dabe40e4bc