### PR TITLE
Hide back button and top bar

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -128,7 +128,6 @@ function openPage(url){
   els.viewer.classList.add('active');
   els.grid.style.display = 'none';
   els.welcome.style.display = 'none';
-  els.backBtn.style.display = history.length > initialHistoryLength ? 'inline-flex' : 'none';
 }
 
 function closePage(){
@@ -136,7 +135,6 @@ function closePage(){
   els.viewer.classList.remove('active');
   els.grid.style.display = '';
   els.welcome.style.display = '';
-  els.backBtn.style.display = 'none';
 }
 
 function tryOpenFromHash(){

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -43,10 +43,10 @@ body {
 .page-desc { color: var(--muted); font-size: 12px; }
 /* Main */
 .main { position: relative; overflow: hidden; }
-.topbar { display: flex; align-items: center; justify-content: space-between; gap: 8px; padding: 12px 14px; border-bottom: 1px solid var(--border); background: linear-gradient(180deg, rgba(255,255,255,.02), transparent); }
+.topbar { display: none; align-items: center; justify-content: space-between; gap: 8px; padding: 12px 14px; border-bottom: 1px solid var(--border); background: linear-gradient(180deg, rgba(255,255,255,.02), transparent); }
 .btn { appearance: none; border: 1px solid var(--border); background: var(--panel); color: var(--text); border-radius: 12px; padding: 10px 12px; cursor: pointer; }
 .btn:hover { border-color: rgba(91,156,255,.6); }
-.content { height: calc(100% - 58px); display: grid; grid-template-rows: auto 1fr; position: relative; }
+.content { height: 100%; display: grid; grid-template-rows: auto 1fr; position: relative; }
 .welcome { padding: 18px; display: grid; gap: 8px; border-bottom: 1px dashed var(--border); }
 .grid { padding: 14px; overflow: auto; }
 .hint { color: var(--muted); font-size: 12px; }


### PR DESCRIPTION
## Summary
- Hide the top bar and back button so the browser back functionality remains without visible controls
- Remove JavaScript that previously toggled back button visibility
- Adjust content layout to fill full height without the header panel

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a18b5fc0ac8325880eeafba9faf802