### PR TITLE
Fix hidden navigation on mobile

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -59,6 +59,7 @@ body {
   .app { grid-template-columns: 1fr; }
   .sidebar { position: fixed; inset: 0 30% 0 0; max-width: 420px; transform: translateX(-100%); transition: transform .25s ease; z-index: 10; box-shadow: 30px 0 80px rgba(0,0,0,.4); }
   .sidebar.open { transform: translateX(0); }
+  .topbar { display: flex; }
   .menu-toggle { display: inline-flex; align-items: center; gap: 8px; }
   .backdrop { display:none; position: fixed; inset: 0; background: rgba(0,0,0,.4); z-index: 9; }
   .backdrop.show { display:block; }


### PR DESCRIPTION
## Summary
- show topbar on narrow screens so menu is accessible

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aa2dd62ebc8325b798f065d2741cfc