### PR TITLE
Improve responsive layouts for mobile and desktop

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -64,3 +64,13 @@ body {
   .backdrop { display:none; position: fixed; inset: 0; background: rgba(0,0,0,.4); z-index: 9; }
   .backdrop.show { display:block; }
 }
+
+/* Small phones */
+@media (max-width: 600px) {
+  .sidebar { inset: 0; max-width: none; }
+}
+
+/* Wide desktops */
+@media (min-width: 1200px) {
+  .app { grid-template-columns: 320px 1fr; }
+}

--- a/pages/physics/style.css
+++ b/pages/physics/style.css
@@ -24,3 +24,9 @@ label{font-size:12px; color:var(--muted)}
 .mathline{margin:2px 0}
 .description{margin-top:24px; background:#111733; padding:16px; border-radius:16px; font-size:14px; line-height:1.6; color:var(--muted)}
 @media (max-width:900px){ .panes, .eqs{grid-template-columns:1fr} }
+
+@media (max-width:600px){
+  .controls{grid-template-columns:1fr; gap:8px;}
+  .wrap{padding:12px;}
+  canvas{height:240px;}
+}


### PR DESCRIPTION
## Summary
- Expand styles for small phones and wide desktops
- Stack physics page controls and shrink canvas on narrow screens

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bc0bdfe3548325be82975d7f9cebd2